### PR TITLE
feat: load env vars from configmap

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   KRATEO_BFF_DEBUG: "{{ .Values.KRATEO_BFF_DEBUG }}"
-  KRATEO_BFF_PORT: "{{ .Values.KRATEO_BFF_PORT }}"
+  KRATEO_BFF_PORT: "{{ .Values.service.targetPort }}"
   AUTHN_STORE_NAMESPACE: {{ .Values.AUTHN_STORE_NAMESPACE }}
  

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  KRATEO_BFF_DEBUG: "{{ .Values.KRATEO_BFF_DEBUG }}"
+  KRATEO_BFF_PORT: "{{ .Values.KRATEO_BFF_PORT }}"
+  AUTHN_STORE_NAMESPACE: {{ .Values.AUTHN_STORE_NAMESPACE }}
+ 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Chart.Name }}
+        - secretRef:
+            name: {{ .Chart.Name }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,9 +1,7 @@
 
-podEnv:
-  - name: KRATEO_BFF_PORT
-    value: "8080"
-  - name: KRATEO_BFF_DEBUG
-    value: "true"
-  - name: AUTHN_STORE_NAMESPACE
-    value: "krateo-system"
+KRATEO_BFF_PORT: "8080"
+KRATEO_BFF_DEBUG: "true"
+AUTHN_STORE_NAMESPACE: "krateo-system"
+
+
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,3 @@
 
-KRATEO_BFF_PORT: "8080"
 KRATEO_BFF_DEBUG: "true"
 AUTHN_STORE_NAMESPACE: "krateo-system"
-
-
-


### PR DESCRIPTION
This Pull Request introduces a feature to load environment variables from a ConfigMap. It aims to enhance Kubernetes deployment flexibility by allowing configurations to be dynamically managed through ConfigMaps. This change facilitates easier adjustments and managing environment-specific settings without directly altering the application's core configuration files.